### PR TITLE
Make frontend call backend for data instead of hardcoding

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -21,6 +21,7 @@ from analytics import views
 router = routers.DefaultRouter()
 router.register(r'teams', views.TeamView, 'team')
 router.register(r'players', views.PlayerView, 'player')
+router.register(r'matches', views.MatchView, 'match')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.1.1",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "bootstrap": "^5.1.3",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -4470,6 +4471,28 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -19437,6 +19460,27 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,10 +2,12 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "bootstrap": "^5.1.3",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -21,10 +21,12 @@
 .group-scroller-container {
   background-color: hsl(0, 0%, 94%);
   height: 400px;
+  width: 100%;
   display: flex;
   flex-direction: row;
   gap: 16px;
   padding: 16px;
+  overflow-x: auto;
 }
 
 .group-card {
@@ -42,6 +44,6 @@
 }
 
 .vs-cell {
-  padding: 0px 8px;
+  padding: 0px 20px;
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,59 +2,150 @@ import React, { Component } from "react";
 import axios from "axios"
 import './App.css';
 
-class Matchup {
-  constructor(team1, team2) {
-    this.team1 = team1
-    this.team2 = team2
+async function getTeamName(team_id) {
+  try {
+    const response = await axios.get('/api/teams/' + team_id);
+    return response.data.name
+  } catch (error) {
+    console.error(error);
   }
 }
 
-const matchup1 = new Matchup('USA', 'Mexico')
-const matchup2 = new Matchup('Spain', 'Portugal')
-const matchup3 = new Matchup('Canada', 'Honduras')
+async function getMatches() {
+  try {
+    const response = await axios.get('/api/matches');
+    return response.data
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function getTeams() {
+  try {
+    const response = await axios.get('/api/teams');
+    return response.data
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function getGroup(chunk, index) {
+  var matchups = []
+  chunk.forEach((match) => {
+    const matchup = new Matchup(match.home_team, match.away_team)
+    matchups.push(matchup)
+  })
+  return {index: index, matchups: matchups}
+}
+
+async function getMatchups(matches) {
+  const groupStMatches = matches.filter(
+    match => match.comp_stage === "Group Stage");
+  const matchupChunks = spliceIntoChunks(groupStMatches, 6)
+
+  var groupMatchups = []
+  await matchupChunks.forEach((chunk, index) => {
+    // 1-based index
+    groupMatchups.push(getGroup(chunk, index + 1))
+  })
+  return groupMatchups
+ }
+
+function spliceIntoChunks(arr, chunkSize) {
+  const res = [];
+  while (arr.length > 0) {
+      const chunk = arr.splice(0, chunkSize);
+      res.push(chunk);
+  }
+  return res;
+}
+
+
+class Matchup {
+  constructor(homeTeamId, awayTeamId) {
+    this.homeTeamId = homeTeamId
+    this.awayTeamId = awayTeamId
+  }
+}
+
 
 class App extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      matches: []
+      matches: [],
+      teams: [],
+      groupMatchups: [] // {index: int, matchups: list[matchups]}
     }
+    
   }
 
-  renderMatchupRow = (matchup) => {
+  // Make ALL API calls here so that all future munging is in-memory
+  async componentDidMount() {
+
+    const matches = await getMatches()
+    const groupMatchups = await getMatchups(matches)
+    const teams = await getTeams()
+    var teamNamesById = {}
+    teams.forEach((team) => {
+      teamNamesById[team.id] = team.name
+    })
+    this.setState({matches: matches,
+                   teamNamesById: teamNamesById,
+                   groupMatchups: groupMatchups})
+  }
+
+  renderMatchupRow(matchup, index) {
+    const homeTeamName = this.state.teamNamesById[matchup.homeTeamId]
+    const awayTeamName = this.state.teamNamesById[matchup.awayTeamId]
+    const vsText = this.state.matches ? 'vs' : ''
     return (
-      <tr className="card-table-row">
-        <td>{matchup.team1}</td>
-        <td className="vs-cell">vs</td>
-        <td>{matchup.team2}</td>
+      <tr key={index.toString()} className="card-table-row">
+        <td>{homeTeamName}</td>
+        <td className="vs-cell">{vsText}</td>
+        <td>{awayTeamName}</td>
       </tr>
     )
   }
 
-  renderCard = (groupNum, matchup1, matchup2, matchup3) => {
+  renderMatchupRows(matchups) {
+    const matchupRows = []
+    matchups.forEach((matchup, index) => {
+      const matchupRow = this.renderMatchupRow(matchup, index)
+      matchupRows.push(matchupRow)
+    })
+    return matchupRows
+  }
+
+  renderCard(groupNum, matchups) {
+    const matchupRows = this.renderMatchupRows(matchups)
+    console.log('card matchup rows', matchupRows)
     return (
       <div className="group-card">
         <h2 className="group-num">Group {groupNum}</h2>
         <table className="card-table">
           <tbody>
-            {this.renderMatchupRow(matchup1)}
-            {this.renderMatchupRow(matchup2)}
-            {this.renderMatchupRow(matchup3)}
+            {matchupRows}
           </tbody>
         </table>
       </div>
     )
   }
 
+  renderCards() {
+    const cards = this.state.groupMatchups.map(
+      groupMatchup => this.renderCard(
+        groupMatchup.index, groupMatchup.matchups));  
+    return cards
+  }
+
   render() {
+    const cards = this.renderCards()
     return (
       <div className="App">
         <h1 id="main-header">World Cup 2018 Analytics</h1> 
         <div className="group-scroller-container">
-          {this.renderCard(1, matchup1, matchup2, matchup3)}
-          {this.renderCard(2, matchup1, matchup2, matchup3)}
-          {this.renderCard(3, matchup1, matchup2, matchup3)}
-          {this.renderCard(4, matchup1, matchup2, matchup3)}
+          {cards}
         </div>
       </div>
     );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
-import logo from './logo.svg';
+import React, { Component } from "react";
+import axios from "axios"
 import './App.css';
 
 class Matchup {
@@ -12,9 +13,15 @@ const matchup1 = new Matchup('USA', 'Mexico')
 const matchup2 = new Matchup('Spain', 'Portugal')
 const matchup3 = new Matchup('Canada', 'Honduras')
 
-function App() {
+class App extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      matches: []
+    }
+  }
 
-  const renderMatchupRow = (matchup) => {
+  renderMatchupRow = (matchup) => {
     return (
       <tr className="card-table-row">
         <td>{matchup.team1}</td>
@@ -24,32 +31,34 @@ function App() {
     )
   }
 
-  const renderCard = (groupNum, matchup1, matchup2, matchup3) => {
+  renderCard = (groupNum, matchup1, matchup2, matchup3) => {
     return (
       <div className="group-card">
         <h2 className="group-num">Group {groupNum}</h2>
         <table className="card-table">
           <tbody>
-            {renderMatchupRow(matchup1)}
-            {renderMatchupRow(matchup2)}
-            {renderMatchupRow(matchup3)}
+            {this.renderMatchupRow(matchup1)}
+            {this.renderMatchupRow(matchup2)}
+            {this.renderMatchupRow(matchup3)}
           </tbody>
         </table>
       </div>
     )
   }
 
-  return (
-    <div className="App">
-      <h1 id="main-header">World Cup 2018 Analytics</h1> 
-      <div className="group-scroller-container">
-        {renderCard(1, matchup1, matchup2, matchup3)}
-        {renderCard(2, matchup1, matchup2, matchup3)}
-        {renderCard(3, matchup1, matchup2, matchup3)}
-        {renderCard(4, matchup1, matchup2, matchup3)}
+  render() {
+    return (
+      <div className="App">
+        <h1 id="main-header">World Cup 2018 Analytics</h1> 
+        <div className="group-scroller-container">
+          {this.renderCard(1, matchup1, matchup2, matchup3)}
+          {this.renderCard(2, matchup1, matchup2, matchup3)}
+          {this.renderCard(3, matchup1, matchup2, matchup3)}
+          {this.renderCard(4, matchup1, matchup2, matchup3)}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 export default App;


### PR DESCRIPTION
Took a slightly different approach, which is to move all API calls to the top level of `componentDidMount`. I was able to remove most of our `async/await` calls by storing a map of team names by id in `App.state`.

So now the `Matchup` class defined in the frontend only stores the team ids and TBH could probably be removed in a future revision unless we decide it could be more useful than just passing the actual matches JSON around